### PR TITLE
Add WinEnter to the setup autocmd to ensure proper win_id

### DIFF
--- a/lua/el/init.lua
+++ b/lua/el/init.lua
@@ -107,7 +107,7 @@ el.setup = function(opts)
   -- Setup autocmds to make sure 
   vim.cmd [=[augroup ExpressLineAutoSetup]=]
   vim.cmd [=[  au!]=]
-  vim.cmd [=[  autocmd BufWinEnter * :lua vim.wo.statusline = string.format([[%%!luaeval('require("el").run(%s)')]], vim.fn.win_getid()) ]=]
+  vim.cmd [=[  autocmd BufWinEnter,WinEnter * :lua vim.wo.statusline = string.format([[%%!luaeval('require("el").run(%s)')]], vim.fn.win_getid()) ]=]
   vim.cmd [=[augroup END]=]
 
   vim.cmd [[doautocmd BufWinEnter]]


### PR DESCRIPTION
This PR adds the WinEnter event to the setup autocmd to ensure that new windows create a status line table with the proper window id, even when the new window does not open a buffer. 

This fixes edge cases where new windows will have a status line that uses the incorrect win_id, allowing logic to check if a status line is on the current window via `vim.api.get_current_win()`. It also fixes a bug where creating a split with no new buffer, switching to the new window, and then closing the window would cause express_line to output "null" in all status lines.