### PR TITLE
Check active window instead of active buffer for mode highlight

### DIFF
--- a/lua/el/extensions.lua
+++ b/lua/el/extensions.lua
@@ -86,13 +86,13 @@ extensions.gen_mode = function(opts)
 
   local format_string = opts.format_string or '[%s]'
 
-  return function(_, buffer)
+  return function(window, buffer)
     local mode = vim.api.nvim_get_mode().mode
 
     local higroup = mode_highlights[mode]
     local display_name = modes[mode][1]
 
-    if not buffer.is_active then
+    if not window.is_active then
       higroup = higroup .. "Inactive"
     end
 

--- a/lua/el/meta.lua
+++ b/lua/el/meta.lua
@@ -46,7 +46,7 @@ local buf_lookups = {
   end,
 
   is_active = function(buffer)
-    return buffer.bufnr ~= vim.api.nvim_get_current_buf()
+    return buffer.bufnr == vim.api.nvim_get_current_buf()
   end
 }
 

--- a/lua/el/meta.lua
+++ b/lua/el/meta.lua
@@ -91,6 +91,10 @@ local win_looksup = {
   height = function(window)
     return vim.api.nvim_win_get_height(window.win_id), false
   end,
+
+  is_active = function(window)
+    return window.win_id == vim.api.nvim_get_current_win(), false
+  end
 }
 
 local window_mt = {


### PR DESCRIPTION
I think check active window is better than check active buffer for mode highlight.