### PR TITLE
fix: missing buffer auto command

### DIFF
--- a/lua/el/subscribe.lua
+++ b/lua/el/subscribe.lua
@@ -93,7 +93,14 @@ subscribe.buf_autocmd = function(identifier, au_events, callback)
       vim.api.nvim_buf_set_var(buffer.bufnr, identifier, callback(nil, buffer) or '')
     end
 
-    return helper.nvim_buf_get_var(buffer.bufnr, identifier)
+    -- nvim_buf_get_var shouldn't return nil, because we set the buffer var to '' if callback returns nil
+    -- we reset subscription here when nil is returned, see issue #40
+    -- new subscription will be setup next time buf_autocmd is called
+    local res = helper.nvim_buf_get_var(buffer.bufnr, identifier)
+    if not res then
+      _ElBufSubscriptions[buffer.bufnr][identifier] = nil
+    end
+    return res
   end
 end
 


### PR DESCRIPTION
this PR should fix #40 

As discussed in #40, buffer auto commands are missing for the first file opened. 

The reason is that before opening the first file, neovim deletes the "No Name" buffer, neovim also deletes all the associate buffer auto commands and the buffer variables. Then, when the we enter the new buffer, express line believes it has already setup all the necessary buffer auto commands because the new buffer has the same buffer number 1.  This is why the first file opened doesn't have any associated buffer auto commands.

The solution is to reset buffer auto command subscription when we detects something wrong. Buffer variables set by express line shouldn't be nil because we set it to an empty string when callbacks return nil. So when we detect a nil buffer variable, we know there's a problem and we reset the subscription.