### PR TITLE
return relative path from file_relative

### DIFF
--- a/lua/el/builtin.lua
+++ b/lua/el/builtin.lua
@@ -17,7 +17,14 @@ builtin.file = function(_, buffer)
 
   return buffer.name
 end
-builtin.file_relative = builtin.file
+
+builtin.file_relative = function(_, buffer)
+  if buffer.name == '' then
+    return builtin.file(_, buffer)
+  end
+
+  return vim.fn.bufname(buffer.bufnr)
+end
 
 --   F S   Full path to the file in the buffer.
 builtin.full_file = function(_, buffer)


### PR DESCRIPTION
This PR should fix https://github.com/tjdevries/express_line.nvim/issues/36
Instead of returning the full path from file_relative, call vim.fn.bufname to return the relative path.

vim.fn.bufname returns full path if current file is not within current directory, which makes sense.