### PR TITLE
Fix: Percentage through file always 3 in length

### DIFF
--- a/lua/el/builtin.lua
+++ b/lua/el/builtin.lua
@@ -155,7 +155,7 @@ builtin.virtual_column_number = '%v'
 builtin.virtual_column_number_long = 'V'
 
 --   p N   Percentage through file in lines as in |CTRL-G|.
-builtin.percentage_through_file = '%p'
+builtin.percentage_through_file = '%3p'
 
 --   P S   Percentage through file of displayed window.  This is like the
 --         percentage described for 'ruler'.  Always 3 in length, unless


### PR DESCRIPTION
Makes Percentage through file always 3 in length.

Befor:
![befor](https://user-images.githubusercontent.com/48415231/111661025-f23dfb00-880e-11eb-85d5-1ad463757834.gif)

After:
![after](https://user-images.githubusercontent.com/48415231/111661148-11d52380-880f-11eb-8977-6b19a52d7c00.gif)
