### PR TITLE
README: Fix config for Git Changes and Git Branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ Outputs a git shortstat output if you are in a git project.
       "el_git_status",
       "BufWritePost",
       function(window, buffer)
-        return extensions.git_changes(window, buffer)
+        local changes =  extensions.git_changes(window, buffer)
+        if changes then
+          return changes
+        end
       end
     ))
     -- ...
@@ -134,7 +137,10 @@ Outputs a git branch info if you are in a git project.
       "el_git_branch",
       "BufEnter",
       function(window, buffer)
-        return extensions.git_branch(window, buffer)
+        local branch = extensions.git_branch(window, buffer)
+        if branch then
+          return branch
+        end
       end
     ))
    -- ...


### PR DESCRIPTION
The provided config for Git Branch and Git Changes causes empty sections and flicker of the statusline on empty buffer.
See gifs below.

I've update the config in the README with the version you use in your dotfiles for Git Branch and do the same for Git Changes. This fixed the issue.

Git Branch:
![git_branch](https://user-images.githubusercontent.com/48415231/111763720-bce2ed00-88a2-11eb-96df-358bb408b528.gif)

Git Changes:
![git_changes](https://user-images.githubusercontent.com/48415231/111763760-c8ceaf00-88a2-11eb-8813-1b407b1337c0.gif)
