### PR TITLE
return real relative path from file_relative

### DIFF
--- a/lua/el/builtin.lua
+++ b/lua/el/builtin.lua
@@ -1,4 +1,5 @@
 local builtin = {}
+local helper = require('el.helper')
 
 -- TODO: It's a bit annoying that we don't know the length of
 -- some of these items until "too late".
@@ -24,7 +25,7 @@ builtin.file_relative = function(_, buffer)
     return builtin.file(_, buffer)
   end
 
-  return vim.fn.bufname(buffer.bufnr)
+  return helper.path_relative(vim.api.nvim_buf_get_name(buffer.bufnr), vim.loop.cwd())
 end
 
 --- <pre>

--- a/lua/el/helper.lua
+++ b/lua/el/helper.lua
@@ -119,4 +119,26 @@ end
 helper.async_win_setter = async_setter("win")
 helper.async_buf_setter = async_setter("buf")
 
+-- add trailing '/' to path if not already there
+local path_add_trailing = function(path)
+  if path:sub(-1) == '/' then
+    return path
+  end
+
+  return path..'/'
+end
+
+--  replace - and . characters with %- and %. for lua to match paths properly
+local path_to_matching_str = function(path)
+  return path:gsub('(%-)', '(%%-)'):gsub('(%.)', '(%%.)'):gsub('(%_)', '(%%_)')
+end
+
+
+-- returns path relative to relative_to
+-- or the unmodified path if path is not under relative_to
+helper.path_relative = function(path, relative_to)
+  local p, _ = path:gsub("^" .. path_to_matching_str(path_add_trailing(relative_to)), "")
+  return p
+end
+
 return helper


### PR DESCRIPTION
This PR tries to fix the following issue:

When I jump to another file with the "go to definition" function of gopls (not sure of other language servers), `vim.fn.bufname` return the absolute path instead of the relative path even if the file is under current directory.

