### PR TITLE
Update vim.lsp.buf_get_clients to vim.lsp.get_clients

### DIFF
--- a/lua/el/plugins/lsp_status.lua
+++ b/lua/el/plugins/lsp_status.lua
@@ -32,7 +32,7 @@ el_lsp_status.server_progress = function(_, buffer)
     return ''
   end
 
-  local buffer_clients = vim.lsp.buf_get_clients(buffer.bufnr)
+  local buffer_clients = vim.lsp.get_clients({ bufnr = buffer.bufnr })
   local buffer_client_set = {}
   for _, v in pairs(buffer_clients) do
     buffer_client_set[v.name] = true


### PR DESCRIPTION
Deprecation of `vim.lsp.buf_get_clients` for Neovim 0.11. `vim.lsp_get_clients` has been available for awhile (not sure exactly when though...)